### PR TITLE
fix(profile): fix style in profile page

### DIFF
--- a/src/routes/(app)/Side.svelte
+++ b/src/routes/(app)/Side.svelte
@@ -79,7 +79,7 @@
       &--single {
           position: sticky;
           height: 100svh;
-          z-index: 1002;
+          z-index: 1000;
 
           @media (max-width: 767px) {
               grid-template-columns: 0;


### PR DESCRIPTION
## What is the current behavior?

I found css style issue when following the steps below:

1. Open profile page in single-column mode.
2. Open image tab and select any image to display the modal.
3. Sidebar is displayed in front of modal.

This pull request includes the above fixes.
For reference, I have attached the current image and the image after the modifications.

### Before

![SCR-20230904-svri](https://github.com/spuithori/tokimekibluesky/assets/8362391/11243bf8-7c0e-4f6d-a74e-57372bf7a982)

### After

![SCR-20230904-svxd](https://github.com/spuithori/tokimekibluesky/assets/8362391/2fe8806f-34d1-4697-9f8e-846cd1cc7d11)

---

It's not a high-priority bug, so please check it when you have time.
Thanks for providing awesome client !!