### PR TITLE
Text color of the 'likes modal'

### DIFF
--- a/src/lib/components/thread/LikesModal.svelte
+++ b/src/lib/components/thread/LikesModal.svelte
@@ -81,6 +81,7 @@
         padding: 30px;
         border-radius: 10px;
         background-color: var(--bg-color-1);
+        color: var(--text-color-3);
         width: 740px;
         max-width: 100%;
         position: relative;


### PR DESCRIPTION
It appears that the 'Likes modal' text color was the User-Agent default. So I added an entry to use `--text-color-3`.

### UA default

<img width="751" alt="スクリーンショット 2023-10-19 22 51 48" src="https://github.com/spuithori/tokimekibluesky/assets/134620/41856335-49f2-476a-afa8-756e1f494efe">

### text-color-3

<img width="751" alt="スクリーンショット 2023-10-19 22 53 15" src="https://github.com/spuithori/tokimekibluesky/assets/134620/a7d1bfb0-e153-4ad4-a533-3794195c2005">

- - - 

🙏 