### PR TITLE
Don't show embed's image div if there is no thumb

### DIFF
--- a/src/lib/components/post/EmbedExternal.svelte
+++ b/src/lib/components/post/EmbedExternal.svelte
@@ -53,8 +53,8 @@
     class:timeline-external--tenor={getTenorUrl(external.uri) && $settings?.embed?.tenor}
   >
     {#if ($settings?.design.externalLayout !== 'compact')}
-      <div class="timeline-external__image">
         {#if (external.thumb)}
+          <div class="timeline-external__image">
           {#if (getYouTubeUrl(external.uri) && $settings?.embed?.youtube)}
             <YouTube youTubeId={getYouTubeUrl(external.uri)}></YouTube>
           {:else if (getSpotifyUri(external.uri) && $settings?.embed?.spotify)}
@@ -91,8 +91,8 @@
           {:else}
             <img src="{external.thumb}" alt="">
           {/if}
+          </div>
         {/if}
-      </div>
     {/if}
 
     <div class="timeline-external__content">


### PR DESCRIPTION
Addresses Issue #99, removes image div when there is no thumbnail. 

> PS Just a small PR and hopefully that's ok. I wanted to do something simple to test the water. Is there anything else I should put in a PR? Any additional testing I should be doing?

[Example ](https://tokimeki.blue/profile/robpc.com/post/3lazztcsfkc2j)

<img width="611" alt="Screenshot 2024-11-19 173537" src="https://github.com/user-attachments/assets/d6a3e13f-a1bb-437f-80ea-35489dcdcc16">

<img width="623" alt="Screenshot 2024-11-19 173526" src="https://github.com/user-attachments/assets/f65a391d-bd69-41cd-ba4e-423fa4f01fad">
