### PR TITLE
相対時間算出処理の修正 | Fix relative time calculation logic

### DIFF
--- a/src/lib/classes/intlRelativeTimeFormatState.svelte.ts
+++ b/src/lib/classes/intlRelativeTimeFormatState.svelte.ts
@@ -1,5 +1,5 @@
-import { differenceInCalendarDays, differenceInCalendarMonths, differenceInCalendarWeeks, differenceInCalendarYears, differenceInHours, differenceInMinutes, differenceInSeconds } from "date-fns";
-import { secondsInDay, secondsInHour, secondsInMinute, secondsInMonth, secondsInWeek, secondsInYear } from "date-fns/constants";
+import { differenceInDays, differenceInHours, differenceInMinutes, differenceInMonths, differenceInSeconds, differenceInWeeks, differenceInYears } from "date-fns";
+import { secondsInDay, secondsInHour, secondsInMinute, secondsInWeek } from "date-fns/constants";
 
 type formatOptions = {
     laterDate: Date,
@@ -22,26 +22,20 @@ class IntlRelativeTimeFormatState {
         } else if (Math.abs(diffInSeconds) < secondsInHour) {
             value = differenceInMinutes(laterDate, earlierDate);
             unit = 'minute';
-        } else if (
-            Math.abs(diffInSeconds) < secondsInDay &&
-            Math.abs(differenceInCalendarDays(laterDate, earlierDate)) < 1
-        ) {
+        } else if (Math.abs(diffInSeconds) < secondsInDay) {
             value = differenceInHours(laterDate, earlierDate);
             unit = 'hour';
-        } else if (
-            Math.abs(diffInSeconds) < secondsInWeek &&
-            (value = differenceInCalendarDays(laterDate, earlierDate)) &&
-            Math.abs(value) < 7
-        ) {
+        } else if (Math.abs(diffInSeconds) < secondsInWeek) {
+            value = differenceInDays(laterDate, earlierDate)
             unit = 'day';
-        } else if (Math.abs(diffInSeconds) < secondsInMonth) {
-            value = differenceInCalendarWeeks(laterDate, earlierDate);
+        } else if (Math.abs(diffInSeconds) < secondsInDay * 30) {
+            value = differenceInWeeks(laterDate, earlierDate);
             unit = 'week';
-        } else if (Math.abs(diffInSeconds) < secondsInYear) {
-            value = differenceInCalendarMonths(laterDate, earlierDate);
+        } else if (Math.abs(diffInSeconds) < secondsInDay * 365) {
+            value = differenceInMonths(laterDate, earlierDate);
             unit = 'month';
         } else {
-            value = differenceInCalendarYears(laterDate, earlierDate);
+            value = differenceInYears(laterDate, earlierDate);
             unit = 'year';
         }
 


### PR DESCRIPTION
## 相対時間表示の計算ロジックを修正

相対時間表示において2つの問題を修正しました。

### 修正した問題点

1. **日付をまたぐ時間表示の問題**
   * 日付が変わるタイミングで、実際の時間差が数時間程度であっても `1d` と表示されていました
   * 例: 23:00から翌日1:00までの2時間の差が「1d」と表示される

2. **過剰な相対時間表示の問題**
   * 1日と少しの時間差が「2d」と表示される
   * 11ヶ月と少しの時間差が「12mo」（1年）と表示される
   * 他の単位でも同様の問題があった

### 修正内容

* カレンダーベースの差分関数（`differenceInCalendarDays`など）から直接の時間差分関数（`differenceInDays`など）に変更
* 月や年の閾値計算を`secondsInDay`に適切な係数を掛けることで明確化（月は30日、年は365日）
* これにより日付をまたいでも正確な時間単位での表示が可能になりました

参考として、Bluesky の公式クライアントも今回の修正に近い実装になっています。
ref: https://github.com/bluesky-social/social-app/blob/1470223480fa993a7186ea1f237db4aa1299ea04/src/lib/hooks/useTimeAgo.ts

### テスト

別ディレクトリにて `IntlRelativeTimeFormatState` のコードを複製し、以下のテストコードでテストしました。

<details>
<summary>テストコード</summary>

```ts
import { expect, test } from "vitest"
import { parseISO } from "date-fns"
import { intlRelativeTimeFormatState } from "../src/time-format"

test("should return 1h", () => {
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2025-04-24T14:30:00Z"), // 2025-04-24T23:30:00+09:00
    earlierDate: parseISO("2025-04-24T15:45:00Z"), // 2025-04-25T00:45:00+09:00
  })

  expect(actual).toBe("1h")
})

test("should return 23h", () => {
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2025-04-23T16:30:00Z"), // 2025-04-24T01:30:00+09:00
    earlierDate: parseISO("2025-04-24T15:30:00Z"), // 2025-04-25T00:30:00+09:00
  })

  expect(actual).toBe("23h")
})

test("should return 1d", () => {
  // duration: 1 day and 1 hour
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2025-04-24T14:30:00Z"), // 2025-04-24T23:30:00+09:00
    earlierDate: parseISO("2025-04-25T15:30:00Z"), // 2025-04-26T00:30:00+09:00
  })

  expect(actual).toBe("1d")
})

test("should return 6d", () => {
  // duration: 6 day and 23 hour
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2025-04-17T16:30:00Z"), // 2025-04-18T01:30:00+09:00
    earlierDate: parseISO("2025-04-24T15:30:00Z"), // 2025-04-25T00:30:00+09:00
  })

  expect(actual).toBe("6d")
})

test("should return 1w", () => {
  // duration: 1 week and 1 hour
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2025-04-18T14:30:00Z"), // 2025-04-18T23:30:00+09:00
    earlierDate: parseISO("2025-04-25T15:30:00Z"), // 2025-04-26T00:30:00+09:00
  })

  expect(actual).toBe("1w")
})

test("should return 4w for just under 1 month", () => {
  // duration: 29 days (just under 30 days)
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2025-03-26T00:00:00Z"), // 2025-03-26T09:00:00+09:00
    earlierDate: parseISO("2025-04-24T00:00:00Z"), // 2025-04-24T09:00:00+09:00
  })

  expect(actual).toBe("4w")
})

test("should return 1mo", () => {
  // duration: 30 days
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2025-03-24T00:00:00Z"), // 2025-03-24T09:00:00+09:00
    earlierDate: parseISO("2025-04-24T00:00:00Z"), // 2025-04-24T09:00:00+09:00
  })

  expect(actual).toBe("1mo")
})

test("should return 11mo for just under 1 year", () => {
  // duration: 364 days (just under 365 days)
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2024-04-26T00:00:00Z"), // 2024-04-26T09:00:00+09:00
    earlierDate: parseISO("2025-04-25T00:00:00Z"), // 2025-04-25T09:00:00+09:00
  })

  expect(actual).toBe("11mo")
})

test("should return 1y", () => {
  // duration: 365 days
  const actual = intlRelativeTimeFormatState.format({
    laterDate: parseISO("2024-04-24T23:59:59Z"), // 2024-04-24T09:00:00+09:00
    earlierDate: parseISO("2025-04-25T00:00:00Z"), // 2025-04-25T09:00:00+09:00
  })

  expect(actual).toBe("1y")
})
```

</details>

---

For English Readers (AI-generated translation)

## Fix Relative Time Calculation Logic

This PR addresses two issues with relative time display calculations.

### Issues Fixed

1. **Cross-midnight Time Display Problem**
   * When times crossed midnight, the formatter would display "1d" even when the actual time difference was only a few hours
   * Example: A 2-hour difference from 23:00 to 1:00 the next day would show as "1d"

2. **Excessive Relative Time Display**
   * A time difference of just over 1 day would display as "2d"
   * A time difference of just over 11 months would display as "12mo" (1 year)
   * Similar issues occurred with other time units

### Implementation Changes

* Changed from calendar-based difference functions (`differenceInCalendarDays`, etc.) to direct time difference functions (`differenceInDays`, etc.)
* Clarified month and year threshold calculations by using `secondsInDay` multiplied by appropriate factors (30 days for months, 365 days for years)
* These changes ensure accurate time unit display even when crossing date boundaries