### PR TITLE
Makes sidebar settings icon non-transparent, and allows scrolling for the settings tabs/TOC

### DIFF
--- a/src/lib/components/side/SideBar.svelte
+++ b/src/lib/components/side/SideBar.svelte
@@ -240,7 +240,7 @@
       width: 48px;
       height: 48px;
       border-radius: 5px;
-      background-color: transparent;
+      background-color: var(--app-bg-color);
       display: grid;
       place-content: center;
       position: relative;

--- a/src/lib/components/side/SideBar.svelte
+++ b/src/lib/components/side/SideBar.svelte
@@ -284,7 +284,7 @@
 
       &--settings {
           position: sticky;
-          bottom: 0;
+          bottom: -8px;
 
       }
 

--- a/src/routes/settings.css
+++ b/src/routes/settings.css
@@ -324,7 +324,7 @@ input[type=checkbox] {
 }
 
 .settings-toc {
-
+    overflow-y: auto;
 }
 
 .theme-store-wrap {


### PR DESCRIPTION
Two small bug fixes.

1. The fixed gear icon to open the Settings menu is transparent, so you get this:

Before:
![image](https://github.com/user-attachments/assets/0a0ac5fc-9f74-4ae4-8e4f-ec8d0a04713f)

After:
<img width="64" alt="Screenshot 2025-05-17 095912_2" src="https://github.com/user-attachments/assets/4129e2e6-25f3-486c-bde3-601e6231f200" />

But as you can see, there is a small gap at the bottom. This is because there's 8px of padding-bottom in the side-bar. If I change the side-bar-button's bottom from 0 to -8px, this will fix the gap. Then scrolling will look like this:

https://github.com/user-attachments/assets/00a69e2f-1649-4a10-bf11-ccbc26c040d7

2. The settings screen's list on the left doesn't scroll, so items below the cut (like Support Tokimeki 😢) are inaccessible. I added a scrollbar to the TOC so that you can scroll and see the items at the bottom:

Before (on the published app so the theme is different)
![Screenshot 2025-05-17 094329](https://github.com/user-attachments/assets/6180f93f-cfec-43dc-8870-0dd3420c4899)

After (local testing):
![Screenshot 2025-05-17 094410](https://github.com/user-attachments/assets/48e03e72-bcfc-4249-83ab-812b073c5bcd)

