### PR TITLE
add disable dragging option to deck settings

### DIFF
--- a/src/lib/components/deck/DeckSettingsModal.svelte
+++ b/src/lib/components/deck/DeckSettingsModal.svelte
@@ -51,6 +51,7 @@
     let opacity = $state(column.settings?.opacity || 100);
     let background = $state(column.settings?.background || '');
     let showReactionViaRepost = $state(column.settings?.showReactionViaRepost || false);
+    let disableDrag = $state(column.settings?.disableDrag || false);
 
     $effect(() => {
         column.settings = {
@@ -76,6 +77,7 @@
             opacity: opacity,
             background: background,
             showReactionViaRepost: showReactionViaRepost,
+            disableDrag: disableDrag,
         }
     })
 
@@ -666,6 +668,20 @@
                             </div>
                         </div>
                     {/if}
+                {/if}
+
+                {#if ($settings.design?.layout === 'default' && !column.settings?.isPopup)}
+                    <dl class="settings-group only-pc">
+                        <dt class="settings-group__name">
+                            {$_('disable_dragging')}
+                        </dt>
+
+                        <dd class="settings-group__content">
+                            <div class="input-toggle">
+                                <input class="input-toggle__input" type="checkbox" id={column.id + 'disableDrag'} bind:checked={disableDrag}><label class="input-toggle__label" for={column.id + 'disableDrag'}></label>
+                            </div>
+                        </dd>
+                    </dl>
                 {/if}
 
                 {#if (column.algorithm?.type === 'custom')}

--- a/src/lib/components/deck/defaultDeckSettings.ts
+++ b/src/lib/components/deck/defaultDeckSettings.ts
@@ -21,6 +21,7 @@ export type defaultDeckSettings = {
         height: number,
     },
     opacity?: number,
+    disableDrag?: boolean,
 }
 
 export const defaultDeckSettings: defaultDeckSettings = {
@@ -39,4 +40,5 @@ export const defaultDeckSettings: defaultDeckSettings = {
     hideCounts: false,
     isPopup: false,
     opacity: 100,
+    disableDrag: false,
 }

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -717,5 +717,6 @@
   "reposted_your_post_via_repost": " reposted via repost",
   "reposted_your_post_via_repost_multiple": " and others reposted via repost",
   "show_reaction_via_repost": "Show reactions to your reposts",
-  "disable_embed_via": "Do not notify those who repost reactions"
+  "disable_embed_via": "Do not notify those who repost reactions",
+  "disable_dragging": "Disable column being draggable"
 }

--- a/src/lib/types/column.ts
+++ b/src/lib/types/column.ts
@@ -32,6 +32,7 @@ type deckSettings = {
     },
     opacity?: number,
     collapse?: boolean,
+    disableDrag?: boolean,
 }
 
 export type Column = {

--- a/src/routes/(app)/DeckRow.svelte
+++ b/src/routes/(app)/DeckRow.svelte
@@ -16,7 +16,7 @@
     import {toast} from "svelte-sonner";
     import ChatTimeline from "./ChatTimeline.svelte";
     import {backgroundsMap} from "$lib/columnBackgrounds";
-    import { draggable, axis, ControlFrom, events, controls, Compartment, position } from '@neodrag/svelte';
+    import { draggable, axis, ControlFrom, events, controls, Compartment, position, disabled } from '@neodrag/svelte';
     import {getColumnState} from "$lib/classes/columnState.svelte";
     import Timeline from "./Timeline.svelte";
     import BookmarkTimeline from "./BookmarkTimeline.svelte";
@@ -307,6 +307,8 @@
         column.data.cursor = undefined;
         unique = Symbol();
     }
+
+    const disabledCompartment = Compartment.of(() => disabled(column.settings?.disableDrag));
 </script>
 
 <div
@@ -326,15 +328,16 @@
     style:background-image={column.settings?.background ? `url(${backgroundsMap.get(column.settings.background).url})` : 'none'}
     class:dragging={isDragging}
     {@attach draggable(() => [
-        axis('x'),
-        controls({ allow: ControlFrom.selector('.deck-drag-area') }),
-        events({
-            onDragStart: handleDragStart,
-            onDrag: handleDragging,
-            onDragEnd: handleDragEnd,
-        }),
-        eventsComp,
-    ])}
+            axis('x'),
+            controls({ allow: ControlFrom.selector('.deck-drag-area') }),
+            events({
+                onDragStart: handleDragStart,
+                onDrag: handleDragging,
+                onDragEnd: handleDragEnd,
+            }),
+            eventsComp,
+            disabledCompartment
+        ])}
 >
     <div class="deck-heading" class:deck-heading--sticky={isJunk && column.algorithm?.type === 'thread'} class:deck-heading--scroll-down={scrollDirectionState.direction === 'down' && !isJunk}>
         {#if (!isJunk)}


### PR DESCRIPTION
Great client! but I ran into a small issue recently. I kept accidentally dragging cards in Single Deck view. Honestly, I'm not even sure what the dragging is meant for there, but it kept getting in my way.

So I added a toggle to disable dragging, currently at the column level. Might be nice to have a global setting too.

I didn’t dig too deep into the codebase, so apologies if I handled the state management in a weird way. Also, I only added the English locale for now.


https://github.com/user-attachments/assets/27a9dfe9-642a-4b34-970c-ece470f2d9c4

