### PR TITLE
i18n: Fix en reporting language

### DIFF
--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -88,7 +88,7 @@
   "unmute_user": "Отмяна на заглушаването",
   "copy_did": "Копиране на DID",
   "success_copy_did": "DID е копиран в клипборда.",
-  "reporting_this_user": "This user has reported the following",
+  "reporting_this_user": "This user has been reported for the following",
   "impersonation": "Impersonation",
   "login": "Вписване",
   "recommend_use_app_password": "Препоръчваме използването на парола за приложение.",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -88,7 +88,7 @@
   "unmute_user": "Unmute",
   "copy_did": "Copy DID",
   "success_copy_did": "DID copied to clipboard.",
-  "reporting_this_user": "This user has reported the following",
+  "reporting_this_user": "This user has been reported for the following",
   "impersonation": "Impersonation",
   "login": "Login",
   "recommend_use_app_password": "We recommend using the app password.",

--- a/src/lib/i18n/locales/fa.json
+++ b/src/lib/i18n/locales/fa.json
@@ -97,7 +97,7 @@
   "unmute_user": "Unmute",
   "copy_did": "Copy DID",
   "success_copy_did": "DID copied to clipboard.",
-  "reporting_this_user": "This user has reported the following",
+  "reporting_this_user": "This user has been reported for the following",
   "impersonation": "Impersonation",
   "login": "Login",
   "recommend_use_app_password": "We recommend using the app password.",


### PR DESCRIPTION
The original language made it seem like the reported user was reporting themselves (for example, reporting their self as rude).

Also fixed other languages where the same English phrase is used.