### PR TITLE
await resumeSession to ensure pdsUrl is available

### DIFF
--- a/src/lib/resumeAccountsSession.ts
+++ b/src/lib/resumeAccountsSession.ts
@@ -30,7 +30,7 @@ async function resume(account, proxy: string | undefined) {
         await ag.configureProxy(proxy);
     }
 
-    ag.resumeSession(account.session)
+    await ag.resumeSession(account.session)
         .then(value => {
             setTimeout(() => {
                 settingsState.setPdsRequestReady();


### PR DESCRIPTION
Thank you for developing such a wonderful client. I use it every day (truly).

When I tried the Appview proxy feature, I noticed that `getTimeline` was being requested to bsky.social. It seems that bsky.social ignores the `atproto-proxy`, so the proxy does not work as expected.
When scrolling the timeline, requests are sent to the PDS instead, which seems to be caused by not properly waiting for the session to [resume](https://github.com/bluesky-social/atproto/blob/2104d9033e2e1a3a7b821c1f0c5c8ffac5832d59/packages/api/src/atp-agent.ts#L406). I’ll fix this by adding an await.

[Retry handling](https://github.com/mkizka/tokimekibluesky/blob/8311f26fbef81d6c106b16eec6a492fbf779bc3f/src/lib/resumeAccountsSession.ts#L47-L49) also needs some fixes, but for now, I’ve created a minimal PR.

---

素晴らしいクライアントを開発して頂きありがとうございます。毎日使っています(本当に)。 

Appviewプロキシ機能を試したところ、`getTimeline`がbsky.socialに対してリクエストされていることに気付きました。bsky.socialは`atproto-proxy`を無視しているようでプロキシが期待通り機能しません。 タイムラインをスクロールするとPDSにリクエストするようになるので、セッションの再開を正しく待機出来ていないことが原因のようです。awaitを追加することで修正します。 

リトライについても修正が必要ですが、まず最小限でPRを作ってみました。

## Before
<img width="1580" height="850" alt="" src="https://github.com/user-attachments/assets/8578f61c-9559-463f-8c3a-93694cf00af7" />

## After
<img width="1577" height="625" alt="" src="https://github.com/user-attachments/assets/1e982fe1-d484-4fd3-a97b-7aac5cd452e0" />
