### PR TITLE
feat: add data-aturi attributes to elements that represent a record

### DIFF
--- a/src/lib/components/notification/NotificationFollowItem.svelte
+++ b/src/lib/components/notification/NotificationFollowItem.svelte
@@ -7,7 +7,7 @@
     let { item, _agent } = $props();
 </script>
 
-<article class="notifications-item notifications-item--follow" class:notifications-item--bubble={$settings?.design?.bubbleTimeline}>
+<article class="notifications-item notifications-item--follow" class:notifications-item--bubble={$settings?.design?.bubbleTimeline} data-aturi={item.uri}>
     <div class="notifications-item__avatar">
         {#if $settings?.design.postsLayout !== 'minimum'}
             <Avatar href="/profile/{ item.author.handle }" avatar={item.author.avatar}

--- a/src/lib/components/notification/NotificationReactionItem.svelte
+++ b/src/lib/components/notification/NotificationReactionItem.svelte
@@ -68,7 +68,7 @@
     }
 </script>
 
-<article class="notifications-item notifications-item--reaction notifications-item--{item.reason}" class:notifications-item--bubble={$settings?.design?.bubbleTimeline}>
+<article class="notifications-item notifications-item--reaction notifications-item--{item.reason}" class:notifications-item--bubble={$settings?.design?.bubbleTimeline} data-aturi={item.uri} data-aturi-subject={item.reasonSubject}>
     <div class="notification-column">
         <div class="notification-column__icons">
             {#if (item.reason === 'repost' || item.reason === 'repost-via-repost')}

--- a/src/lib/components/post/EmbedRecord.svelte
+++ b/src/lib/components/post/EmbedRecord.svelte
@@ -91,7 +91,7 @@
   }
 </script>
 
-<div class="timeline-external timeline-external--record">
+<div class="timeline-external timeline-external--record" data-aturi={record?.uri}>
   {#if (isMuted && !isMuteDisplay)}
     <div class="thread-notice thread-notice--quote" class:thread-notice--shown={isMuteDisplay}>
       <p class="thread-notice__text">{$_('muted_user_embed')}<br>

--- a/src/lib/components/post/TimelineContent.svelte
+++ b/src/lib/components/post/TimelineContent.svelte
@@ -158,7 +158,7 @@
   {/if}
 </div>
 
-<div class="timeline__content">
+<div class="timeline__content" data-aturi={post.uri}>
   <div class="timeline__meta">
     <p class="timeline__user">
       { post.author.displayName || post.author.handle }

--- a/src/routes/(app)/TimelineItem.svelte
+++ b/src/routes/(app)/TimelineItem.svelte
@@ -557,7 +557,7 @@
 
       {#if (!isThread)}
         {#if (isReasonRepost(data.reason))}
-          <p class="timeline-repost-message">
+          <p class="timeline-repost-message" data-aturi={data.reason.uri}>
             <ProfileCardWrapper handle={data.reason.by.handle} {_agent}>
               <a href="/profile/{data.reason.by.did}"><Repeat2 size="18" color="var(--primary-color)"></Repeat2><span class="timeline-repost-message__text">{$_('reposted_by', {values: {name: data.reason.by.displayName || data.reason.by.handle}})}</span></a>
             </ProfileCardWrapper>


### PR DESCRIPTION
adding data-aturi attributes (and data-aturi-subject for reaction notifications) to elements that represent a record (eg. posts, notifications). rationale for this is that i'm writing a web extension that needs this kind of data and tokimeki currently doesn't have any way to identify posts etc. in the DOM, so this will make tokimeki support in the extension possible (https://tangled.org/@poor.dog/at-fronter).