### PR TITLE
非Bluesky PDSユーザーのレコード取得失敗の修正

### DIFF
--- a/src/lib/components/post/TimelineContent.svelte
+++ b/src/lib/components/post/TimelineContent.svelte
@@ -15,7 +15,7 @@
   import { toast } from "svelte-sonner";
   import FeedsItem from "$lib/components/feeds/FeedsItem.svelte";
   import EmbedRecordDetached from "$lib/components/post/EmbedRecordDetached.svelte";
-  import {getAllAgentDids, getDidFromUri} from "$lib/util";
+  import {getAllAgentDids, getDidFromUri, getService} from "$lib/util";
   import EmbedVideo from "$lib/components/post/EmbedVideo.svelte";
   import ReactionButtons from "$lib/components/post/ReactionButtons.svelte";
   import {onDestroy, untrack} from "svelte";
@@ -149,7 +149,19 @@
 
   async function handleSkyblurShow() {
       try {
-          const __agent = new BskyAgent({service: _agent.service()});
+          let pdsEndpoint: string;
+
+          if (post.author.handle.endsWith(".bsky.social")) {
+            pdsEndpoint = _agent.service();
+          } else {
+            const endpoint = await getService(post.author.did);
+            if (!endpoint) {
+              throw new Error("Could not resolve PDS endpoint.");
+            }
+            pdsEndpoint = endpoint;
+          }
+
+          const __agent = new BskyAgent({ service: pdsEndpoint });
           const rkey = post?.record?.['uk.skyblur.post.uri'].split('/').slice(-1)[0];
           const res = await __agent.api.com.atproto.repo.getRecord({
               collection: "uk.skyblur.post",


### PR DESCRIPTION
## 概要
Skyblurのポストを取得する箇所の`getRecord` において、Bluesky系列のPDS以外のサーバー（セルフホストPDSなど）を利用しているユーザーのレコードが取得できない問題を修正しました。

## 修正内容
従来のロジックではすべてのユーザーに対して同一の処理を行っていましたが、ハンドルによって参照先を切り替えるように変更しました。

* **Bluesky PDSユーザー (`*.bsky.social`)**
  * 従来どおりのロジックで処理を継続します。
* **その他のユーザー（セルフホスト等の可能性あり）**
  * `plc.directory` を経由して適切なPDSを特定し、レコードを取得するようにしました。