### PR TITLE
Use separate replace regex to rewrite relative times

### DIFF
--- a/src/lib/classes/intlRelativeTimeFormatState.svelte.ts
+++ b/src/lib/classes/intlRelativeTimeFormatState.svelte.ts
@@ -50,7 +50,7 @@ class IntlRelativeTimeFormatState {
         }
 
         const formattedString = this.instance.format(value, unit);
-        return formattedString.replace(/(in | ago|-)/g, '').trim();
+        return formattedString.replace(/^in /, '').replace(/ ago$/, '').replace(/^-/, '').trim();
     }
 
     changeLocale(locale: string) {


### PR DESCRIPTION
Turns relative time strings like `in 3m` and `3m ago` into `3m` (and also removes any leading `-` characters, just in case negative numbers show up). This uses multiple `replace` calls to resolve #168. However, non-`en`-like locales will probably not benefit, for example:

```js
> value = -3;
> unit = "minute";
> instance = new Intl.RelativeTimeFormat("es", { numeric: 'always', style: 'narrow' });
> console.log(instance.format(value, unit));
hace 3 min
```

So more improvements could be made here if reducing the output of `Intl.RelativeTimeFormat` is considered important for other locales.