### PR TITLE
リストに表示されるメンバー数で list.listItemCount を参照するよう修正

### DIFF
--- a/src/lib/components/list/OfficialListItem.svelte
+++ b/src/lib/components/list/OfficialListItem.svelte
@@ -17,6 +17,7 @@
     _agent?: any;
     list?: any;
     title?: string;
+    listItemCount?: number;
     isModerationList?: any;
     uri?: string;
     isMute?: boolean;
@@ -29,6 +30,7 @@
     _agent = $agent,
     list = $bindable(undefined),
     title = $bindable(''),
+    listItemCount = $bindable(0),
     isModerationList = $bindable(list?.purpose === 'app.bsky.graph.defs#modlist' || false),
     uri = '',
     isMute = $bindable(false),
@@ -45,6 +47,7 @@
               list = value.data.list;
               items = value.data.items;
               title = list.name;
+              listItemCount = list.listItemCount;
               isModerationList = list.purpose === 'app.bsky.graph.defs#modlist';
               isMute = list?.viewer?.muted;
               isBlock = list?.viewer?.blocked;
@@ -102,7 +105,7 @@
 
       <p class="list-item__description">
         {#if items.length}
-          <button class="list-item__members-button" onclick={() => {isMembersOpen = true}}>{items.length}{$_('list_members_length_suffix')}</button>
+          <button class="list-item__members-button" onclick={() => {isMembersOpen = true}}>{listItemCount}{$_('list_members_length_suffix')}</button>
           {#if (isMembersOpen)}
             <OfficialListMembersModal members={items} onclose={() => {isMembersOpen = false}}></OfficialListMembersModal>
           {/if}


### PR DESCRIPTION
> [!WARNING]
> 軽微な修正ですが、私は Svelte を使ったことがないので入念にレビューをお願いします 🙏 

## 現在の動作

`/lists/{uri}` でリストを表示したとき、メンバーの数が fetch した件数となっています。

<img width="228" height="59" alt="SCR-20260215-qwat" src="https://github.com/user-attachments/assets/1acaaa7a-a35c-4b85-b5fe-8712d234ba34" />

## 修正後の動作

レスポンスに含まれる `list.listItemCount` を参照してリストに追加されているメンバー数が正しく表示されるようにしました。

<img width="232" height="65" alt="SCR-20260215-qwpi" src="https://github.com/user-attachments/assets/239f878e-16ef-4583-af17-8e66a7cf4abc" />

ref: https://docs.bsky.app/docs/api/app-bsky-graph-get-list