### PR TITLE
Add a clear feed feature

### DIFF
--- a/src/routes/(app)/DeckColumn.svelte
+++ b/src/routes/(app)/DeckColumn.svelte
@@ -15,7 +15,7 @@
     import ListTimeline from "./ListTimeline.svelte";
     import {scrollDirectionState} from "$lib/classes/scrollDirectionState.svelte";
     import {scrollDirection} from "$lib/scrollDirection";
-    import {Settings2, CheckCheck, GripVertical} from "lucide-svelte";
+    import {Settings2, CheckCheck, GripVertical, Eraser} from "lucide-svelte";
     import { createLongPress } from "$lib/longpress";
     import {getColumnState} from "$lib/classes/columnState.svelte";
 
@@ -123,6 +123,11 @@
         }, 2000);
     }
 
+    function handleClearFeed() {
+        column.data.clearedAt = new Date().toISOString();
+        handleForceRefresh();
+    }
+
     function handleSettingsClick(clear = false) {
         isSettingsOpen = !isSettingsOpen;
 
@@ -220,6 +225,12 @@
             {isSplit}
             {column}
         ></ColumnRefreshButton>
+
+        {#if !isJunk}
+            <button class="deck-column-header__action-button" aria-label="Clear feed" title="Clear feed" onclick={handleClearFeed}>
+                <Eraser color="var(--deck-row-settings-button-color, var(--text-color-3))" strokeWidth="var(--icon-stroke-width, 2px)"></Eraser>
+            </button>
+        {/if}
 
         {#if !isJunk}
             <button class="deck-column-header__settings-button" class:deck-column-header__settings-button--open={isSettingsOpen} aria-label="Settings" onclick={() => {isSettingsOpen = !isSettingsOpen}}>

--- a/src/routes/(app)/Timeline.svelte
+++ b/src/routes/(app)/Timeline.svelte
@@ -68,6 +68,14 @@
                   return false;
               }
 
+              const clearedAt = column.data.clearedAt;
+              if (clearedAt) {
+                  const postTime = value.reason?.indexedAt || value.post?.indexedAt;
+                  if (postTime && postTime <= clearedAt) {
+                      return false;
+                  }
+              }
+
               columnState.updateFeed(column.id, f => { f.unshift(value); });
               realtimeCounter = realtimeCounter + 1;
 
@@ -222,11 +230,24 @@
             ])
         );
 
+        let hitClearBoundary = false;
+
         const feed = res.data.feed
             .filter(feed => {
                 const key = feed.reason ? `${feed.post.uri}|${feed.reason.indexedAt}` : feed.post.uri;
                 const existing = existingFeedMap.get(key);
-                return !existing || !isDuplicatePost(existing, feed);
+                if (existing && isDuplicatePost(existing, feed)) return false;
+                
+                const clearedAt = column.data.clearedAt;
+                if (clearedAt) {
+                    const postTime = feed.reason?.indexedAt || feed.post?.indexedAt;
+                    if (postTime <= clearedAt) {
+                        hitClearBoundary = true;
+                        return false;
+                    }
+                }
+
+                return true;
             })
             .map(item => {
                 item.memoryCursor = res.data.cursor;
@@ -270,7 +291,7 @@
 
           isDividerLoading = false;
 
-          if (column.data.cursor) {
+          if (column.data.cursor && !hitClearBoundary) {
               loaded();
           } else {
               complete();


### PR DESCRIPTION
The only deck.blue feature I'm missing is the clear feed feature so I tried to add my own. I haven't deployed or tested yet because I don't have a dev env set up.

At first I tried a purely cursor based method but in the end this seemed easier. I think it should work for both regular and realtime feeds?