### PR TITLE
Fix double decoding of share URL parameters

### DIFF
--- a/src/routes/(app)/shared/+page.svelte
+++ b/src/routes/(app)/shared/+page.svelte
@@ -18,7 +18,7 @@
   const url = params.get('url') ? '<br><a href="' + params.get('url') + '">' + params.get('url') : '</a>';
 
   onMount(async () => {
-      postState.replaceText(decodeURIComponent(title) + decodeURIComponent(text) + decodeURIComponent(url));
+      postState.replaceText(title + text + url);
 
       if (!isNomove) {
           await goto('/');


### PR DESCRIPTION
共有機能で、URLパラメータが二重にデコードされていた問題を修正しました。

`URLSearchParams.get`はデコード済み文字列を返しますが、その結果をさらに`decodeURIComponent`に通していました。そのため二重デコードとなり、パラメータによっては誤った文字列が入力されたり、エラーが発生したりします。

## 再現

1. 開発サーバーを起動します
2. `http://localhost:5173/shared?text=%25`にアクセスします
3. 共有テキストは入力されず、ブラウザでエラーが発生します: `Uncaught URIError URIError: URI malformed`

この例では、本来`%25`に対応する`%`が入力されるべきですが、ここで出てきた`%`をさらにデコードしようとするため、無効な引数としてエラーが発生します。

ここで有効な文字列が出てくる場合、例えば`%E5%8B%9D%E7%8E%871%2520%E9%80%A3%E6%95%97%E4%B8%AD` (勝率1%20連敗中) は、二重デコードによって`%20`がスペースに化け、「勝率1 連敗中」となります。

---

Fixed an issue where URL parameters were double-decoded in the sharing feature.

`URLSearchParams.get` returns a decoded string, but the result was further passed through `decodeURIComponent`. This led to double decoding, causing incorrect strings to be input or errors to occur depending on the parameters.

## Reproduction


1. Start the development server.
2. Access `http://localhost:5173/shared?text=%25`.
3. The shared text is not entered, and an error occurs in the browser: `Uncaught URIError URIError: URI malformed`.

In this example, `%` corresponding to `%25` should normally be entered, but an error occurs as an invalid argument because the app attempts to decode the resulting `%` again.

If it results in a valid string, for example, `%E5%8B%9D%E7%8E%871%2520%E9%80%A3%E6%95%97%E4%B8%AD` (勝率1%20連敗中), it will be decoded twice, causing `%20` to turn into a space, resulting in "勝率1 連敗中".
