### PR TITLE
Fix missing `yy` format specifier in dateFormat utility

### DIFF
--- a/src/lib/dateFormat.ts
+++ b/src/lib/dateFormat.ts
@@ -3,6 +3,7 @@ export function formatDate(date: Date | number, format: string): string {
   const pad = (n: number) => String(n).padStart(2, '0');
   return format
     .replace('yyyy', String(d.getFullYear()))
+    .replace('yy', String(d.getFullYear()).slice(-2))
     .replace('MM', pad(d.getMonth() + 1))
     .replace('dd', pad(d.getDate()))
     .replace('HH', pad(d.getHours()))


### PR DESCRIPTION
日付時刻を文字列に変換する`dateFormat`ユーティリティには、`yy`の変換がありませんでした。
このPRは、それによって`yy`を含む時刻表示設定にしたときに日付表示が壊れる問題を修正します。

---

The `dateFormat` utility for converting date and time to a string did not have `yy` conversion.
This PR fixes an issue where the date display would be broken when the time display setting included `yy`.