### PR TITLE
feat: Display hostname in external embeds

### DIFF
--- a/src/lib/components/post/EmbedExternal.svelte
+++ b/src/lib/components/post/EmbedExternal.svelte
@@ -5,6 +5,8 @@
   import EmbedKlipy from "$lib/components/post/EmbedKlipy.svelte";
   import EmbedX from "$lib/components/post/EmbedX.svelte";
   import EmbedPoll from "$lib/components/post/EmbedPoll.svelte";
+  import { LinkIcon } from "lucide-svelte";
+  import { _ } from "svelte-i18n";
 
   interface Props {
     external: any;
@@ -14,6 +16,8 @@
   let { external, _agent }: Props = $props();
 
   const pollInfo = getPollUrl(external.uri);
+  const url = new URL(external.uri);
+  const hostname = url.hostname;
 </script>
 
 {#if pollInfo && _agent}
@@ -88,6 +92,8 @@
       {#if (external.description)}
         <p class="timeline-external__description">{external.description}</p>
       {/if}
+
+      <p class="timeline-external__host"><LinkIcon class="timeline-external__host__icon" size="14" aria-label={$_('external_link_hostname')} />{hostname}</p>
     </div>
   </div>
 {/if}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -941,5 +941,6 @@
   "blog_error": "Failed to load blog posts",
   "mochott_timeline": "Timeline (mochott)",
   "network_feed": "standard.site",
-  "monochrome": "Monochrome mode"
+  "monochrome": "Monochrome mode",
+  "external_link_hostname": "External link hostname"
 }

--- a/src/lib/i18n/locales/ja.json
+++ b/src/lib/i18n/locales/ja.json
@@ -941,5 +941,6 @@
   "blog_error": "ブログの読み込みに失敗しました",
   "mochott_timeline": "タイムライン (mochott)",
   "network_feed": "standard.site",
-  "monochrome": "白黒モード"
+  "monochrome": "白黒モード",
+  "external_link_hostname": "リンク先のホスト名"
 }

--- a/src/routes/timeline.css
+++ b/src/routes/timeline.css
@@ -108,6 +108,19 @@
         font-size: 13px;
     }
 
+    &__host {
+        color: var(--timeline-embed-color);
+        font-size: 13px;
+        margin-top: 8px;
+        word-break: break-all;
+
+        &__icon {
+            display: inline;
+            margin-right: 4px;
+            vertical-align: middle;
+        }
+    }
+
     &__url {
         color: var(--timeline-embed-color);
         white-space: nowrap;
@@ -819,7 +832,7 @@
         position: absolute;
         left: 29px;
         width: 2px;
-        background-image: linear-gradient(to top,var(--border-color-2) 4px, transparent 4px);
+        background-image: linear-gradient(to top, var(--border-color-2) 4px, transparent 4px);
         background-repeat: repeat-y;
         background-position: left bottom;
         background-size: 4px 8px;


### PR DESCRIPTION
タイムライン上で、外部リンクの埋め込みの下部にリンク先URLのホスト名を表示するようにしました。

これにより、リンクカードのリンクを踏む前にリンク先を認識できるようになります。

---

Added the hostname of the destination URL to the bottom of external link embeds on the timeline.

This allows users to identify the destination before clicking on link cards.

---

<img width="380" height="515" alt="image" src="https://github.com/user-attachments/assets/941354ab-8c86-4056-9a9a-f04120149885" />