### PR TITLE
feat: increase bottom margin for `次回から確認しない` checkbox area

### DIFF
--- a/src/lib/components/ui/ConfirmModal.svelte
+++ b/src/lib/components/ui/ConfirmModal.svelte
@@ -66,6 +66,6 @@
 
 <style lang="postcss">
     .skip-confirmation {
-      margin-bottom: 16px;
+      margin-bottom: 32px;
   }
 </style>


### PR DESCRIPTION
スマートフォンで使っているときに、投稿の削除や削除&編集をしようとして上のチェックボックスに手が当たってしまい、手動で設定を戻すことが何回かあったので、ボタンとチェックボックスの隙間を少し広げてみました。

## Before

- <img width="177" height="186" alt="image" src="https://github.com/user-attachments/assets/002251ee-f1b4-4cf2-aed9-e77e89fa44e4" />
- <img width="297" height="246" alt="image" src="https://github.com/user-attachments/assets/72694386-2aea-4d6c-9491-bea005091bfe" />

## After

- <img width="177" height="204" alt="image" src="https://github.com/user-attachments/assets/82f7e481-84aa-49ab-8cf5-c2213bc643c5" />
- <img width="291" height="264" alt="image" src="https://github.com/user-attachments/assets/ad153896-7697-4b67-ad50-df2d53d3edf4" />