### PR TITLE
feat: add View original post link

### DIFF
--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -944,5 +944,6 @@
   "blog_error": "Failed to load blog posts",
   "mochott_timeline": "Timeline (mochott)",
   "network_feed": "standard.site",
-  "monochrome": "Monochrome mode"
+  "monochrome": "Monochrome mode",
+  "open_original_post": "View original post ({hostname})"
 }

--- a/src/lib/i18n/locales/ja.json
+++ b/src/lib/i18n/locales/ja.json
@@ -944,5 +944,6 @@
   "blog_error": "ブログの読み込みに失敗しました",
   "mochott_timeline": "タイムライン (mochott)",
   "network_feed": "standard.site",
-  "monochrome": "白黒モード"
+  "monochrome": "白黒モード",
+  "open_original_post": "元の投稿を見る ({hostname})"
 }

--- a/src/routes/(app)/TimelineItem.svelte
+++ b/src/routes/(app)/TimelineItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {_} from 'svelte-i18n'
-  import { Trash2, Languages, Copy, AtSign, List, Flag, EyeOff, Rss, Pin, Pencil, Sticker, Repeat2, Reply, VolumeX, ShieldBan, BellOff, Bell } from 'lucide-svelte';
+  import { Trash2, Languages, Copy, AtSign, List, Flag, EyeOff, Rss, Pin, Pencil, Sticker, Repeat2, Reply, VolumeX, ShieldBan, BellOff, Bell, Star } from 'lucide-svelte';
   import { agent, settings, reportModal, listAddModal, agents, repostMutesSet, postMutes, postMutesSet, bluefeedAddModal, pulseDetach, junkAgentDid, agentDidsSet } from '$lib/stores';
   import { AppBskyEmbedRecord, AppBskyEmbedRecordWithMedia, AppBskyEmbedVideo, AppBskyFeedDefs } from '$lib/atproto-guards'
   import { hasGalleryImages } from '$lib/components/post/embedImages'
@@ -69,6 +69,16 @@
         postUri: data?.post?.uri,
         authorDid: data?.post?.author?.did,
       };
+    });
+
+    const originalUrl: URL | undefined = $derived.by(() => {
+      if (data?.post?.record?.bridgyOriginalUrl) {
+        const url = URL.parse(data.post.record.bridgyOriginalUrl);
+        if (url && url.protocol === 'https:' && url.hostname && !url.username && !url.password) {
+          return url;
+        }
+      }
+      return undefined;
     });
 
     if ($settings.general?.deleteConfirmSkip === undefined) {
@@ -607,6 +617,15 @@
 
         {#snippet content()}
           <ul class="timeline-menu-list">
+            {#if (originalUrl)}
+              <li class="timeline-menu-list__item timeline-menu-list__item--original">
+                <a class="timeline-menu-list__button" href={originalUrl.href} target="_blank" rel="noopener nofollow noreferrer">
+                  <Star size="18" />
+                  {$_('open_original_post', {values: {hostname: originalUrl.hostname}})}
+                </a>
+              </li>
+            {/if}
+
             {#if ($agentDidsSet.has(data.post.author.did))}
               <li class="timeline-menu-list__item timeline-menu-list__item--delete">
                 <button class="timeline-menu-list__button" onclick={deletePostStep}>


### PR DESCRIPTION
Bridgyでブリッジされた投稿のコンテキストメニューに、元の投稿を見るためのリンクを追加しました。ラベルにリンク先のホスト名を表示しています。

<img width="445" height="282" alt="image" src="https://github.com/user-attachments/assets/e53324a0-419a-4a8f-a772-c50cefff71fd" />
